### PR TITLE
Configurable Tritter serving address

### DIFF
--- a/tritter/server/server.go
+++ b/tritter/server/server.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	listenAddr = "localhost:50051"
+var (
+	listenAddr = flag.String("listen_addr", "localhost:50051", "the address the server is listening on")
 )
 
 // server is used to implement TritterServer.

--- a/tritter/server/server.go
+++ b/tritter/server/server.go
@@ -27,13 +27,13 @@ func (s *server) Send(ctx context.Context, in *tritter.SendRequest) (*tritter.Se
 
 func main() {
 	flag.Parse()
-	lis, err := net.Listen("tcp", listenAddr)
+	lis, err := net.Listen("tcp", *listenAddr)
 	if err != nil {
 		glog.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer()
 	tritter.RegisterTritterServer(s, &server{})
-	glog.Infof("Serving tritter on %v", listenAddr)
+	glog.Infof("Serving tritter on %v", *listenAddr)
 	if err := s.Serve(lis); err != nil {
 		glog.Fatalf("failed to serve: %v", err)
 	}


### PR DESCRIPTION
Would like to be able to pass server address. To serve on a GCP VM's external IP, listenAddr needs to be internal IP of VM, which is only known once VM is spun up.