### PR TITLE
Use prototext marshaling in client too

### DIFF
--- a/tritbot/client/client.go
+++ b/tritbot/client/client.go
@@ -95,11 +95,7 @@ func (t *tritBot) Send(ctx context.Context, msg log.InternalMessage) error {
 			return fmt.Errorf("failed to verify log root: %v", err)
 		}
 
-		bs, err := proto.Marshal(&msg)
-		if err != nil {
-			return fmt.Errorf("could not marshal log message: %v", err)
-		}
-
+		bs := byte[](proto.MarshalTextString(&msg))
 		if err := t.v.VerifyInclusionByHash(root, t.v.BuildLeaf(bs).MerkleLeafHash, r.GetProof().GetProof()); err != nil {
 			return fmt.Errorf("could not verify inclusion proof: %v", err)
 		}


### PR DESCRIPTION
Otherwise the inclusion proof verification won't work.